### PR TITLE
Adding beforehide option to the feedback widget

### DIFF
--- a/README
+++ b/README
@@ -81,6 +81,10 @@ OPTIONS
   // The dialog element is passed as argument
   onshow: function(){},
 
+  // When the user closes the window, but before the window is destroyed.
+  // The dialog element is passed as argument
+  beforehide: function(){},
+
   // Deprecated...
 
   // When the user opens the window

--- a/feedback.js
+++ b/feedback.js
@@ -51,6 +51,10 @@ window.FeedbackOptions = jQuery.extend({
 	// When the user opens the window
 	// The dialog element is passed as argument
 	onshow: function(){},
+
+  // When the user closes the window, but before the window is destroyed
+  // The dialog element is passed as argument
+  beforehide: function(){},
 	
 	// Deprecated...
 	
@@ -151,6 +155,9 @@ jQuery(document).ready(function() {
 		
 		// Function to hide the dialog
 		var _hide = function(e) {
+      // Trigger the beforehide callback
+      if (options.beforehide)
+        options.beforehide(dialog_em[0]);
 			$(document).unbind('.feedback_dialog');
 			dialog_em.remove();
 			mask_em.remove();


### PR DESCRIPTION
Hello,

I'm from Curious.com, and i found that I wanted to have a hide callback in addition to the show callback that you guys already provide in your feedback widget.  I considered calling it "onhide", but changed it to "beforehide", because i figured it would be more useful to run the callback before everything gets destroyed, and might as well be clear about that behavior.

Would love to see this get pulled in.  Let me know if you have any questions or if there's anything else i can do.

Thanks!
- Henry
